### PR TITLE
Update to include version for Bludit 3

### DIFF
--- a/items/auto-archive/metadata.json
+++ b/items/auto-archive/metadata.json
@@ -4,7 +4,7 @@
 	"release_date": "2018-10-06",
 	"license": "MIT",
 	"price_usd": "0",
-	"download_url": "https://github.com/BlakesHeaven/Auto-Archive-Menu-Plus-More/archive/v3.0.0.zip",
+	"download_url_v3": "https://github.com/BlakesHeaven/Auto-Archive-Menu-Plus-More/archive/v3.0.0.zip",
 	"demo_url": "",
 	"information_url": "https://github.com/BlakesHeaven/Auto-Archive-Menu-Plus-More",
 	"description": "Published content moves through three different sections automatically based on the published date.",


### PR DESCRIPTION
I've added a new folder in my repository for a Bludit 3 compatible version.
Please keep it pointing to Master.zip as I keep a complete plugin version in separate folders.
BTW - I have had to strip back functionality by removing the "Admin Stuff" section restriction to only show content to Admin/Editors. This is because Bludit 3 can't surface the logged-in user role to the plugin any more!