### PR TITLE
Removed trailing slashes

### DIFF
--- a/items/open-links-new-tab-pilab/meta.json
+++ b/items/open-links-new-tab-pilab/meta.json
@@ -5,9 +5,9 @@
 	"release_date": "2019-05-30",
 	"license": "MIT",
 	"price_usd": "0",
-	"download_url": "https://pilab.dev/plugins/",
-	"demo_url": "https://pilab.dev/",
-	"information_url": "https://pilab.dev/",
+	"download_url": "https://pilab.dev/plugins",
+	"demo_url": "https://pilab.dev",
+	"information_url": "https://pilab.dev",
 	"description": "Set all external links to open in new tabs.",
 	"features": {}
 }


### PR DESCRIPTION
The download link on the Bludit Plugins page is not working. I removed the trailing slashes to see if that fixes it. That was the only difference that I noticed from the template and other examples.