### PR TITLE
add vanilla-comments plugin

### DIFF
--- a/authors/christian-tietze.json
+++ b/authors/christian-tietze.json
@@ -1,0 +1,7 @@
+{
+	"name": "Christian Tietze",
+	"email": "hi@christiantietze.de",
+	"website": "https://christiantietze.de",
+	"twitter": "https://twitter.com/ctietze",
+	"github": "https://github.com/DivineDominion"
+}

--- a/items/vanilla-comments/metadata.json
+++ b/items/vanilla-comments/metadata.json
@@ -1,0 +1,20 @@
+{
+	"name": "Vanilla Comments",
+	"version": "0.1.0",
+	"author_username": "christian-tietze",
+	"release_date": "2019-08-26",
+	"license": "MIT",
+	"price_usd": "0",
+	"download_url": "https://github.com/DivineDominion/vanilla-comments/archive/v0.1.0.zip",
+	"information_url": "https://github.com/DivineDominion/vanilla-comments/",
+	"description": "Use Vanilla Forum embed comments",
+	"features": {
+		"0": "Conditional activation/deactivation of comments per page",
+		"1": "Configurable comment position",
+	},
+	"description_de": "Verwende Vanilla Forum zum Einbetten von Kommentaren",
+	"features": {
+		"0": "(De)aktiviere Kommentare bei Bedarf auf einzelnen Seiten",
+		"1": "Konfigurierbare Position der Kommentare auf der Seite",
+	},
+}

--- a/items/vanilla-comments/metadata.json
+++ b/items/vanilla-comments/metadata.json
@@ -1,20 +1,22 @@
 {
 	"name": "Vanilla Comments",
-	"version": "0.1.0",
+	"version": "0.2.0",
 	"author_username": "christian-tietze",
 	"release_date": "2019-08-26",
 	"license": "MIT",
 	"price_usd": "0",
-	"download_url": "https://github.com/DivineDominion/vanilla-comments/archive/v0.1.0.zip",
+	"download_url": "https://github.com/DivineDominion/vanilla-comments/archive/v0.2.0.zip",
 	"information_url": "https://github.com/DivineDominion/vanilla-comments/",
 	"description": "Use Vanilla Forum embed comments",
 	"features": {
 		"0": "Conditional activation/deactivation of comments per page",
 		"1": "Configurable comment position",
+		"2": "Configurable target category in the forums for new comment discussions",
 	},
 	"description_de": "Verwende Vanilla Forum zum Einbetten von Kommentaren",
 	"features": {
 		"0": "(De)aktiviere Kommentare bei Bedarf auf einzelnen Seiten",
 		"1": "Konfigurierbare Position der Kommentare auf der Seite",
+		"2": "Konfigurierbare Vanilla-Forum Kategorie, in die Kommentare gespeichert werden",
 	},
 }


### PR DESCRIPTION
I'd like to move the plugin from my personal account to the https://github.com/bludit-plugins/ group if possible to encourage community editing.

Plugin repo:
https://github.com/DivineDominion/vanilla-comments/