### PR TITLE
Fix broken-link-checker's broken link

### DIFF
--- a/items/broken-link-checker/metadata.json
+++ b/items/broken-link-checker/metadata.json
@@ -4,7 +4,7 @@
 	"release_date": "2019-11-07",
 	"license": "MIT",
 	"price_usd": "0",
-	"download_url": "https://github.com/anaggh/broken-link-checker/archive/1.0.zip",
+	"download_url": "https://github.com/ali-demirtas/broken-link-checker/archive/1.0.zip",
 	"download_url_v2": "",
 	"demo_url": "",
 	"information_url": "https://github.com/anaggh/broken-link-checker",
@@ -20,5 +20,5 @@
 	"description_ru": "Сканирует сайт на наличие нерабочих (битых) ссылок и изображений, а также помогает в их исправлении.",
 	"features_ru": {
 	},
-	"author_username": "anaggh"
+	"author_username": "ali-demirtas"
 }

--- a/items/broken-link-checker/metadata.json
+++ b/items/broken-link-checker/metadata.json
@@ -20,5 +20,5 @@
 	"description_ru": "Сканирует сайт на наличие нерабочих (битых) ссылок и изображений, а также помогает в их исправлении.",
 	"features_ru": {
 	},
-	"author_username": "ali-demirtas"
+	"author_username": "anaggh"
 }


### PR DESCRIPTION
Original repository not available anymore, maybe user name change?

Now available via:
https://github.com/ali-demirtas/broken-link-checker/

Commit history shows user @jadeops, not 'anaggh', but @jadeops also doesn't have that repo